### PR TITLE
Fix sp core dependency in ex06

### DIFF
--- a/exercises/ex06-weights/weights/Cargo.toml
+++ b/exercises/ex06-weights/weights/Cargo.toml
@@ -19,6 +19,7 @@ frame-support = { git = "https://github.com/paritytech/substrate.git", branch = 
 frame-system  = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28", default-features = false }
 sp-io         = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28", default-features = false }
 sp-std        = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28", default-features = false }
+sp-core        = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28", default-features = false }
 
 [dev-dependencies]
 pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }

--- a/exercises/ex06-weights/weights/src/lib.rs
+++ b/exercises/ex06-weights/weights/src/lib.rs
@@ -74,7 +74,7 @@ pub mod pallet {
 			if address == Some(who.clone()) {
 				Self::deposit_event(Event::IsRoot(who));
 			} else {
-				return Err(Error::<T>::Invalid.into())
+				return Err(Error::<T>::Invalid.into());
 			}
 
 			Ok(())


### PR DESCRIPTION
When trying to test `ex06`, I get a failed build because of a missing dependency on it:

```
exercises/ex06-weights on git main is pkg v0.1.0 via rs v1.65.0
✦ > cargo test
   Compiling sp-core v6.0.0 (https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28#ce10b9f2)
   Compiling sp-trie v6.0.0 (https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28#ce10b9f2)
   Compiling sp-keystore v0.12.0 (https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28#ce10b9f2)
   Compiling sp-state-machine v0.12.0 (https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28#ce10b9f2)
   Compiling sp-io v6.0.0 (https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28#ce10b9f2)
   Compiling sp-application-crypto v6.0.0 (https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28#ce10b9f2)
   Compiling sp-runtime v6.0.0 (https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28#ce10b9f2)
   Compiling sp-version v5.0.0 (https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28#ce10b9f2)
   Compiling sp-inherents v4.0.0-dev (https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28#ce10b9f2)
   Compiling sp-staking v4.0.0-dev (https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28#ce10b9f2)
   Compiling sp-api v4.0.0-dev (https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28#ce10b9f2)
   Compiling frame-support v4.0.0-dev (https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28#ce10b9f2)
   Compiling frame-system v4.0.0-dev (https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28#ce10b9f2)
   Compiling frame-benchmarking v4.0.0-dev (https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28#ce10b9f2)
   Compiling pallet-balances v4.0.0-dev (https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28#ce10b9f2)
   Compiling pallet-weight v0.1.0 (/Users/afm/Code/a-moreira/Forks/substrate-tutorials/exercises/ex06-weights/weights)
error[E0432]: unresolved import `sp_core`
 --> exercises/ex06-weights/weights/src/mock.rs:8:5
  |
8 | use sp_core::H256;
  |     ^^^^^^^ use of undeclared crate or module `sp_core`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `pallet-weight` due to previous error
```